### PR TITLE
fix(*): quote -var value to allow for spaces, etc.

### DIFF
--- a/examples/basic-tf-example/porter.yaml
+++ b/examples/basic-tf-example/porter.yaml
@@ -12,6 +12,12 @@ parameters:
     path: /cnab/app/terraform/terraform.tfstate
     source:
       output: tfstate
+    applyTo:
+      - upgrade
+      - uninstall
+      - show
+      - plan
+      - printVersion
   - name: myvar
     type: string
     default: "porter rocks!"
@@ -53,7 +59,7 @@ plan:
         no-color:
         out: "/dev/null"
         var:
-          - "myvar={{bundle.parameters.myvar}}"
+          - "'myvar={{bundle.parameters.myvar}}'"
 
 # Note: this can't be 'version:' as this would conflict with top-level field
 # Hence the need for the 'arguments:' override

--- a/examples/basic-tf-example/porter.yaml
+++ b/examples/basic-tf-example/porter.yaml
@@ -12,12 +12,6 @@ parameters:
     path: /cnab/app/terraform/terraform.tfstate
     source:
       output: tfstate
-    applyTo:
-      - upgrade
-      - uninstall
-      - show
-      - plan
-      - printVersion
   - name: myvar
     type: string
     default: "porter rocks!"

--- a/pkg/terraform/install.go
+++ b/pkg/terraform/install.go
@@ -29,7 +29,7 @@ func (m *Mixin) Install() error {
 	}
 
 	for _, k := range sortKeys(step.Vars) {
-		step.Flags = append(step.Flags, builder.NewFlag("var", fmt.Sprintf("%s=%s", k, step.Vars[k])))
+		step.Flags = append(step.Flags, builder.NewFlag("var", fmt.Sprintf("'%s=%s'", k, step.Vars[k])))
 	}
 
 	action.Steps[0] = step

--- a/pkg/terraform/invoke.go
+++ b/pkg/terraform/invoke.go
@@ -31,7 +31,7 @@ func (m *Mixin) Invoke(opts InvokeOptions) error {
 	step.Arguments = commands
 
 	for _, k := range sortKeys(step.Vars) {
-		step.Flags = append(step.Flags, builder.NewFlag("var", fmt.Sprintf("%s=%s", k, step.Vars[k])))
+		step.Flags = append(step.Flags, builder.NewFlag("var", fmt.Sprintf("'%s=%s'", k, step.Vars[k])))
 	}
 
 	action.Steps[0] = step

--- a/pkg/terraform/uninstall.go
+++ b/pkg/terraform/uninstall.go
@@ -25,7 +25,7 @@ func (m *Mixin) Uninstall() error {
 	step.Flags = append(step.Flags, builder.NewFlag("auto-approve"))
 
 	for _, k := range sortKeys(step.Vars) {
-		step.Flags = append(step.Flags, builder.NewFlag("var", fmt.Sprintf("%s=%s", k, step.Vars[k])))
+		step.Flags = append(step.Flags, builder.NewFlag("var", fmt.Sprintf("'%s=%s'", k, step.Vars[k])))
 	}
 
 	action.Steps[0] = step


### PR DESCRIPTION
* Adds logic to surround a given `-var` value with single quotes, to allow for vars with spaces, etc. 

Used the examples/guidelines from Terraform via https://www.terraform.io/docs/configuration/variables.html#variables-on-the-command-line

Noticed that the example bundle was failing as the `myvar` default value of `"porter rocks!"` was getting split when running the command:

```
...
Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
stat rocks!: no such file or directory
err: error running command terraform apply -auto-approve -input=false -var myvar=porter rocks!: exit status 1
Error: error running command terraform apply -auto-approve -input=false -var myvar=porter rocks!: exit status 1
...
```