### PR TITLE
Fix make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,9 @@ bin/porter-runtime:
 	chmod +x bin/porter-runtime
 
 install:
-	mkdir -p $(PORTER_HOME)/mixins/$(MIXIN)
+	mkdir -p $(PORTER_HOME)/mixins/$(MIXIN)/runtimes
 	install $(BINDIR)/$(MIXIN)$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/$(MIXIN)$(FILE_EXT)
-	install $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/$(MIXIN)-runtime$(FILE_EXT)
+	install $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/runtimes/$(MIXIN)-runtime$(FILE_EXT)
 
 clean: clean-packr clean-last-testrun
 	-rm -fr bin/

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ REGISTRY ?= $(USER)
 build: build-client build-runtime
 
 build-runtime: generate
-	mkdir -p $(BINDIR)
-	GOARCH=$(RUNTIME_ARCH) GOOS=$(RUNTIME_PLATFORM) $(GO) build -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) ./cmd/$(MIXIN)
+	mkdir -p $(BINDIR)/runtimes
+	GOARCH=$(RUNTIME_ARCH) GOOS=$(RUNTIME_PLATFORM) $(GO) build -ldflags '$(LDFLAGS)' -o $(BINDIR)/runtimes/$(MIXIN)-runtime$(FILE_EXT) ./cmd/$(MIXIN)
 
 build-client: generate
 	mkdir -p $(BINDIR)
@@ -74,7 +74,7 @@ test-integration: xbuild
 	cp $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT) $(BINDIR)/$(MIXIN)$(FILE_EXT)
 	$(GO) test -tags=integration ./tests/...
 
-test-cli: clean-last-testrun bin/porter$(FILE_EXT) bin/porter-runtime build install init-porter-home-for-ci
+test-cli: clean-last-testrun bin/porter$(FILE_EXT) bin/runtimes/porter-runtime build install init-porter-home-for-ci
 	./scripts/test/test-cli.sh
 
 init-porter-home-for-ci:
@@ -100,14 +100,15 @@ bin/porter$(FILE_EXT):
 	curl -fsSLo bin/porter$(FILE_EXT) https://cdn.porter.sh/canary/porter-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)
 	chmod +x bin/porter$(FILE_EXT)
 
-bin/porter-runtime:
-	curl -fsSLo bin/porter-runtime https://cdn.porter.sh/canary/porter-linux-amd64
-	chmod +x bin/porter-runtime
+bin/runtimes/porter-runtime:
+	mkdir -p bin/runtimes
+	curl -fsSLo bin/runtimes/porter-runtime https://cdn.porter.sh/canary/porter-linux-amd64
+	chmod +x bin/runtimes/porter-runtime
 
 install:
 	mkdir -p $(PORTER_HOME)/mixins/$(MIXIN)/runtimes
 	install $(BINDIR)/$(MIXIN)$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/$(MIXIN)$(FILE_EXT)
-	install $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/runtimes/$(MIXIN)-runtime$(FILE_EXT)
+	install $(BINDIR)/runtimes/$(MIXIN)-runtime$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/runtimes/$(MIXIN)-runtime$(FILE_EXT)
 
 clean: clean-packr clean-last-testrun
 	-rm -fr bin/

--- a/build/testdata/bundles/terraform/porter.yaml
+++ b/build/testdata/bundles/terraform/porter.yaml
@@ -3,7 +3,7 @@ mixins:
 
 name: terraform
 version: 0.1.0
-tag: getporterci/terraform:v0.1.0
+registry: getporterci
 
 parameters:
   - name: file_contents

--- a/examples/azure-aks/porter.yaml
+++ b/examples/azure-aks/porter.yaml
@@ -3,7 +3,7 @@ mixins:
 
 name: terraform-aks
 version: 0.1.0
-tag: getporter/terraform-aks
+registry: getporter
 
 credentials:
   - name: subscription_id

--- a/examples/azure-keyvault/porter.yaml
+++ b/examples/azure-keyvault/porter.yaml
@@ -4,7 +4,7 @@ mixins:
 
 name: terraform-keyvault
 version: 0.1.0
-tag: getporter/terraform-keyvault
+registry: getporter
 
 credentials:
   - name: subscription_id

--- a/examples/basic-tf-example/porter.yaml
+++ b/examples/basic-tf-example/porter.yaml
@@ -4,7 +4,7 @@ mixins:
 
 name: basic-tf-example
 version: 0.1.0
-tag: getporterci/basic-tf-example
+registry: getporterci
 
 parameters:
   - name: tfstate

--- a/scripts/test/test-cli.sh
+++ b/scripts/test/test-cli.sh
@@ -12,7 +12,8 @@ trap popd EXIT
 
 function verify-output() {
   # Verify the output matches the expected value
-  if [[ "$(${PORTER_HOME}/porter installation output show $1)" != "$2" ]]; then
+  output=`${PORTER_HOME}/porter installation output show $1`
+  if [[ "${output}" != "$2" ]]; then
     echo "Output '$1' value: '${output}' does not match expected"
     return 1
   fi


### PR DESCRIPTION
The runtime was moved, it should now be installed to ~/.porter/mixins/MIXIN/runtimes/MIXIN-runtime

Signed-off-by: Carolyn Van Slyck <me@carolynvanslyck.com>