### PR TITLE
Use -raw when retrieving outputs

### DIFF
--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -48,7 +48,7 @@ func (m *Mixin) getPayloadData() ([]byte, error) {
 }
 
 func (m *Mixin) getOutput(outputName string) ([]byte, error) {
-	cmd := m.NewCommand("terraform", "output", outputName)
+	cmd := m.NewCommand("terraform", "output", "-raw", outputName)
 	cmd.Stderr = m.Err
 
 	// Terraform appears to auto-append a newline character when printing outputs


### PR DESCRIPTION
Use the new -raw flag that preserves the previous functionality of terraform output, since -json still outputs quotes so you still have to parse it. Raw outputs a usable value.

https://github.com/hashicorp/terraform/issues/27100#issuecomment-742541630

Fixes #68 