### PR TITLE
Bump default Terraform version to 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Terraform client version can be specified via the `clientVersion` configurat
 
 ```yaml
 - terraform:
-    clientVersion: 0.12.17
+    clientVersion: 1.0.3
 ```
 
 ## Terraform state

--- a/build/testdata/bundles/terraform/terraform/variables.tf
+++ b/build/testdata/bundles/terraform/terraform/variables.tf
@@ -1,3 +1,4 @@
 variable "file_contents" {
   description = "Contents of the file 'foo'"
+  default = "bar"
 }

--- a/examples/azure-aks/porter.yaml
+++ b/examples/azure-aks/porter.yaml
@@ -38,7 +38,7 @@ parameters:
 
   - name: kubernetes_version
     type: string
-    default: "1.14.8"
+    default: "1.21.2"
     env: TF_VAR_kubernetes_version
 
   - name: agent_count

--- a/examples/azure-aks/terraform/main.tf
+++ b/examples/azure-aks/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-    version         = "~>1.37.0"
+    features {}
     subscription_id = var.subscription_id
     client_id       = var.client_id
     client_secret   = var.client_secret
@@ -7,6 +7,12 @@ provider "azurerm" {
 }
 
 terraform {
-    required_version = "~>0.12.17"
+    required_version = "1.0.4"
+    required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=2.72.0"
+    }
+  }
     backend "azurerm" {}
 }

--- a/examples/azure-keyvault/terraform/main.tf
+++ b/examples/azure-keyvault/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-    version         = "~>1.37.0"
+    features {}
     subscription_id = var.subscription_id
     client_id       = var.client_id
     client_secret   = var.client_secret
@@ -7,6 +7,12 @@ provider "azurerm" {
 }
 
 terraform {
-    required_version = "~>0.12.17"
+    required_version = "1.0.4"
+    required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=2.72.0"
+    }
+  }
     backend "azurerm" {}
 }

--- a/examples/basic-tf-example/porter.yaml
+++ b/examples/basic-tf-example/porter.yaml
@@ -1,6 +1,6 @@
 mixins:
   - terraform:
-      clientVersion: 0.12.29
+      clientVersion: 1.0.0
 
 name: basic-tf-example
 version: 0.1.0

--- a/pkg/terraform/build_test.go
+++ b/pkg/terraform/build_test.go
@@ -25,7 +25,7 @@ func TestMixin_Build(t *testing.T) {
 		err := m.Build()
 		require.NoError(t, err)
 
-		wantOutput := fmt.Sprintf(buildOutputTemplate, "0.12.17")
+		wantOutput := fmt.Sprintf(buildOutputTemplate, "1.0.4")
 
 		gotOutput := m.TestContext.GetOutput()
 		assert.Equal(t, wantOutput, gotOutput)

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -18,7 +18,7 @@ import (
 // DefaultWorkingDir is the default working directory for Terraform
 const DefaultWorkingDir = "/cnab/app/terraform"
 
-const defaultTerraformVersion = "0.12.17"
+const defaultTerraformVersion = "1.0.4"
 
 // terraform is the logic behind the terraform mixin
 type Mixin struct {

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -48,7 +48,7 @@ func (m *Mixin) getPayloadData() ([]byte, error) {
 }
 
 func (m *Mixin) getOutput(outputName string) ([]byte, error) {
-	cmd := m.NewCommand("terraform", "output", outputName)
+	cmd := m.NewCommand("terraform", "output", "-raw", outputName)
 	cmd.Stderr = m.Err
 
 	// Terraform appears to auto-append a newline character when printing outputs


### PR DESCRIPTION
This PR bumps the default Terraform version to `1.0.4`

- [x] Tests
- [x] Examples 
- [x] Docs 

fixes #70 