### PR TITLE
fix(install.go): allow for empty var block when generating tfvars file

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ file from the `vars` block during during the install step.
 
 To use this file, a `tfvars` file parameter and output must be added to persist it for subsequent steps.
 
-
-
 This can be disabled by setting `disableVarFile` to `true` during install.
 
 Here is an example setup using the tfvar file:

--- a/pkg/terraform/install.go
+++ b/pkg/terraform/install.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -47,9 +46,9 @@ func (m *Mixin) Install() error {
 			return err
 		}
 
-		// If vbs is "null", as would be the case if step.Vars is empty,
-		// set vbs to an empty JSON object so that terraform doesn't error out.
-		if bytes.Equal(vbs, []byte("null")) {
+		// If the vars block is empty, set vbs to an empty JSON object
+		// to prevent terraform from erroring out
+		if len(step.Vars) == 0 {
 			vbs = []byte("{}")
 		}
 

--- a/pkg/terraform/install.go
+++ b/pkg/terraform/install.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -40,14 +41,23 @@ func (m *Mixin) Install() error {
 			return err
 		}
 		defer vf.Close()
+
 		vbs, err := json.Marshal(step.Vars)
 		if err != nil {
 			return err
 		}
+
+		// If vbs is "null", as would be the case if step.Vars is empty,
+		// set vbs to an empty JSON object so that terraform doesn't error out.
+		if bytes.Equal(vbs, []byte("null")) {
+			vbs = []byte("{}")
+		}
+
 		_, err = vf.Write(vbs)
 		if err != nil {
 			return err
 		}
+
 		if m.Debug {
 			fmt.Fprintf(m.Err, "DEBUG: TF var file created:\n%s\n", string(vbs))
 		}

--- a/pkg/terraform/testdata/install-input-no-vars-block.yaml
+++ b/pkg/terraform/testdata/install-input-no-vars-block.yaml
@@ -1,0 +1,7 @@
+install:
+- terraform:
+    description: "Install MySQL"
+    input: false
+    logLevel: TRACE
+    backendConfig:
+      key: "my.tfstate"


### PR DESCRIPTION
* When install is called with no `vars` block and is running in the default mode of creating a tfvars file, set the generated tfvars file to an empty JSON object rather than the "null" string returned from json.Marshal

i.e., avoids:

```
╷
│ Error: Root value must be object
│
│   on terraform.tfvars.json line 1:
│    1: null
│
│ The root value in a JSON-based configuration must be either a JSON object
│ or a JSON array of objects.
╵
```

Fixes https://github.com/getporter/terraform-mixin/issues/74