### PR TITLE
ref(*): remove input field

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ outputs:
 install:
   - terraform:
       description: "Install Azure Key Vault"
-      input: false
       vars:
         foo: bar
         baz: biz
@@ -114,13 +113,11 @@ install:
 upgrade: # No var block required
   - terraform:
       description: "Install Azure Key Vault"
-      input: false
       outputs:
       - name: vault_uri
 uninstall: # No var block required
   - terraform:
       description: "Install Azure Key Vault"
-      input: false
       outputs:
       - name: vault_uri
 ```
@@ -142,7 +139,6 @@ parameters:
 install:
   - terraform:
       description: "Install Azure Key Vault"
-      input: false
       disableVarFile: true
       vars:
         foo: bar
@@ -152,7 +148,6 @@ install:
 uninstall: # Var block required
   - terraform:
       description: "Install Azure Key Vault"
-      input: false
       vars:
         foo: bar
         baz: biz
@@ -166,7 +161,6 @@ uninstall: # Var block required
 install:
   - terraform:
       description: "Install Azure Key Vault"
-      input: false
       backendConfig:
         key: "mybundle.tfstate"
         storage_account_name: "mystorageacct"
@@ -182,7 +176,6 @@ install:
 upgrade:
   - terraform:
       description: "Upgrade Azure Key Vault"
-      input: false
       backendConfig:
         key: "mybundle.tfstate"
         storage_account_name: "mystorageacct"

--- a/examples/azure-aks/porter.yaml
+++ b/examples/azure-aks/porter.yaml
@@ -69,7 +69,6 @@ customActions:
 install:
   - terraform:
       description: "Install Azure Kubernetes Service"
-      input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
         storage_account_name: "{{ bundle.credentials.backend_storage_account }}"
@@ -79,7 +78,6 @@ install:
 upgrade:
   - terraform:
       description: "Upgrade Azure Kubernetes Service"
-      input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
         storage_account_name: "{{ bundle.credentials.backend_storage_account }}"

--- a/examples/azure-keyvault/porter.yaml
+++ b/examples/azure-keyvault/porter.yaml
@@ -52,7 +52,6 @@ customActions:
 install:
   - terraform:
       description: "Install Azure Key Vault"
-      input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
         storage_account_name: "{{ bundle.credentials.backend_storage_account }}"
@@ -64,7 +63,6 @@ install:
 upgrade:
   - terraform:
       description: "Upgrade Azure Key Vault"
-      input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
         storage_account_name: "{{ bundle.credentials.backend_storage_account }}"

--- a/pkg/terraform/action.go
+++ b/pkg/terraform/action.go
@@ -108,7 +108,6 @@ type TerraformFields struct {
 	Vars           map[string]string `yaml:"vars,omitempty"`
 	DisableVarFile bool              `yaml:"disableVarFile,omitempty"`
 	LogLevel       string            `yaml:"logLevel,omitempty"`
-	Input          bool              `yaml:"input,omitempty"`
 	BackendConfig  map[string]string `yaml:"backendConfig,omitempty"`
 }
 

--- a/pkg/terraform/action_test.go
+++ b/pkg/terraform/action_test.go
@@ -30,9 +30,8 @@ func TestMixin_UnmarshalStep(t *testing.T) {
 	assert.Equal(t, "custom", step.Arguments[0])
 
 	sort.Sort(step.Flags)
-	require.Len(t, step.Flags, 4)
+	require.Len(t, step.Flags, 3)
 	assert.Equal(t, builder.NewFlag("backendConfig", "key=my.tfstate"), step.Flags[0])
-	assert.Equal(t, builder.NewFlag("input", "false"), step.Flags[1])
-	assert.Equal(t, builder.NewFlag("logLevel", "TRACE"), step.Flags[2])
-	assert.Equal(t, builder.NewFlag("vars", "myvar=foo"), step.Flags[3])
+	assert.Equal(t, builder.NewFlag("logLevel", "TRACE"), step.Flags[1])
+	assert.Equal(t, builder.NewFlag("vars", "myvar=foo"), step.Flags[2])
 }

--- a/pkg/terraform/install.go
+++ b/pkg/terraform/install.go
@@ -29,10 +29,6 @@ func (m *Mixin) Install() error {
 	// Always run in non-interactive mode
 	step.Flags = append(step.Flags, builder.NewFlag("auto-approve"))
 
-	if !step.Input {
-		step.Flags = append(step.Flags, builder.NewFlag("input=false"))
-	}
-
 	// Only create a tf var file for install
 	if !step.DisableVarFile && action.Name == "install" {
 		vf, err := m.FileSystem.Create(path.Join(m.WorkingDir, defaultTerraformVarsFilename))

--- a/pkg/terraform/install.go
+++ b/pkg/terraform/install.go
@@ -28,6 +28,7 @@ func (m *Mixin) Install() error {
 	step.Arguments = []string{"apply"}
 	// Always run in non-interactive mode
 	step.Flags = append(step.Flags, builder.NewFlag("auto-approve"))
+	step.Flags = append(step.Flags, builder.NewFlag("input=false"))
 
 	// Only create a tf var file for install
 	if !step.DisableVarFile && action.Name == "install" {

--- a/pkg/terraform/install_test.go
+++ b/pkg/terraform/install_test.go
@@ -31,7 +31,6 @@ func TestMixin_UnmarshalInstallStep(t *testing.T) {
 
 	assert.Equal(t, "Install MySQL", step.Description)
 	assert.Equal(t, "TRACE", step.LogLevel)
-	assert.Equal(t, false, step.Input)
 	assert.Equal(t, false, step.DisableVarFile)
 }
 
@@ -39,7 +38,7 @@ func TestMixin_Install(t *testing.T) {
 	defer os.Unsetenv(test.ExpectedCommandEnv)
 	expectedCommand := strings.Join([]string{
 		"terraform init -backend=true -backend-config=key=my.tfstate -reconfigure",
-		"terraform apply -auto-approve -input=false -var myvar=foo",
+		"terraform apply -auto-approve -var myvar=foo",
 	}, "\n")
 	os.Setenv(test.ExpectedCommandEnv, expectedCommand)
 
@@ -78,7 +77,6 @@ func TestMixin_UnmarshalInstallSaveVarStep(t *testing.T) {
 
 	assert.Equal(t, "Install MySQL", step.Description)
 	assert.Equal(t, "TRACE", step.LogLevel)
-	assert.Equal(t, false, step.Input)
 	assert.Equal(t, true, step.DisableVarFile)
 }
 
@@ -86,7 +84,7 @@ func TestMixin_InstallDisableSaveVars(t *testing.T) {
 	defer os.Unsetenv(test.ExpectedCommandEnv)
 	expectedCommand := strings.Join([]string{
 		"terraform init -backend=true -backend-config=key=my.tfstate -reconfigure",
-		"terraform apply -auto-approve -input=false -var myvar=foo",
+		"terraform apply -auto-approve -var myvar=foo",
 	}, "\n")
 	os.Setenv(test.ExpectedCommandEnv, expectedCommand)
 

--- a/pkg/terraform/install_test.go
+++ b/pkg/terraform/install_test.go
@@ -38,7 +38,7 @@ func TestMixin_Install(t *testing.T) {
 	defer os.Unsetenv(test.ExpectedCommandEnv)
 	expectedCommand := strings.Join([]string{
 		"terraform init -backend=true -backend-config=key=my.tfstate -reconfigure",
-		"terraform apply -auto-approve -var myvar=foo",
+		"terraform apply -auto-approve -input=false -var myvar=foo",
 	}, "\n")
 	os.Setenv(test.ExpectedCommandEnv, expectedCommand)
 
@@ -84,7 +84,7 @@ func TestMixin_InstallDisableSaveVars(t *testing.T) {
 	defer os.Unsetenv(test.ExpectedCommandEnv)
 	expectedCommand := strings.Join([]string{
 		"terraform init -backend=true -backend-config=key=my.tfstate -reconfigure",
-		"terraform apply -auto-approve -var myvar=foo",
+		"terraform apply -auto-approve -input=false -var myvar=foo",
 	}, "\n")
 	os.Setenv(test.ExpectedCommandEnv, expectedCommand)
 

--- a/pkg/terraform/schema/schema.json
+++ b/pkg/terraform/schema/schema.json
@@ -51,9 +51,6 @@
             ]
           }
         },
-        "input": {
-          "type": "boolean"
-        },
         "logLevel": {
           "type": "string"
         },
@@ -100,9 +97,6 @@
                   "string"
                 ]
               }
-            },
-            "input": {
-              "type": "boolean"
             },
             "logLevel": {
               "type": "string"

--- a/pkg/terraform/testdata/bad-upgrade-disable-save-var.yaml
+++ b/pkg/terraform/testdata/bad-upgrade-disable-save-var.yaml
@@ -1,7 +1,6 @@
 upgrade:
   - terraform:
       description: "Upgrade MySQL"
-      input: false
       logLevel: TRACE
       disableVarFile: true
       backendConfig:

--- a/pkg/terraform/testdata/install-input-disable-save-vars.yaml
+++ b/pkg/terraform/testdata/install-input-disable-save-vars.yaml
@@ -1,7 +1,6 @@
 install:
   - terraform:
       description: "Install MySQL"
-      input: false
       logLevel: TRACE
       disableVarFile: true
       backendConfig:

--- a/pkg/terraform/testdata/install-input.yaml
+++ b/pkg/terraform/testdata/install-input.yaml
@@ -1,7 +1,6 @@
 install:
 - terraform:
     description: "Install MySQL"
-    input: false
     logLevel: TRACE
     backendConfig:
       key: "my.tfstate"

--- a/pkg/terraform/testdata/invoke-input.yaml
+++ b/pkg/terraform/testdata/invoke-input.yaml
@@ -3,7 +3,6 @@ custom:
     description: "Custom Action"
     arguments:
       - "custom"
-    input: false
     logLevel: TRACE
     backendConfig:
       key: my.tfstate

--- a/pkg/terraform/testdata/step-input.yaml
+++ b/pkg/terraform/testdata/step-input.yaml
@@ -4,7 +4,6 @@ custom:
     arguments:
       - "custom"
     flags:
-      input: false
       logLevel: TRACE
       backendConfig:
         - "key=my.tfstate"

--- a/pkg/terraform/testdata/upgrade-input.yaml
+++ b/pkg/terraform/testdata/upgrade-input.yaml
@@ -1,7 +1,6 @@
 upgrade:
 - terraform:
     description: "Upgrade MySQL"
-    input: false
     logLevel: TRACE
     backendConfig:
       key: "my.tfstate"

--- a/pkg/terraform/uninstall.go
+++ b/pkg/terraform/uninstall.go
@@ -23,6 +23,7 @@ func (m *Mixin) Uninstall() error {
 	step.Arguments = []string{"destroy"}
 	// Always run in non-interactive mode
 	step.Flags = append(step.Flags, builder.NewFlag("auto-approve"))
+	step.Flags = append(step.Flags, builder.NewFlag("input=false"))
 
 	for _, k := range sortKeys(step.Vars) {
 		step.Flags = append(step.Flags, builder.NewFlag("var", fmt.Sprintf("'%s=%s'", k, step.Vars[k])))

--- a/pkg/terraform/uninstall_test.go
+++ b/pkg/terraform/uninstall_test.go
@@ -30,7 +30,7 @@ func TestMixin_Uninstall(t *testing.T) {
 	defer os.Unsetenv(test.ExpectedCommandEnv)
 	expectedCommand := strings.Join([]string{
 		"terraform init -backend=true -backend-config=key=my.tfstate -reconfigure",
-		"terraform destroy -auto-approve -var myvar=foo",
+		"terraform destroy -auto-approve -input=false -var myvar=foo",
 	}, "\n")
 	os.Setenv(test.ExpectedCommandEnv, expectedCommand)
 

--- a/pkg/terraform/upgrade_test.go
+++ b/pkg/terraform/upgrade_test.go
@@ -30,7 +30,7 @@ func TestMixin_Upgrade(t *testing.T) {
 	defer os.Unsetenv(test.ExpectedCommandEnv)
 	expectedCommand := strings.Join([]string{
 		"terraform init -backend=true -backend-config=key=my.tfstate -reconfigure",
-		"terraform apply -auto-approve -var myvar=foo",
+		"terraform apply -auto-approve -input=false -var myvar=foo",
 	}, "\n")
 	os.Setenv(test.ExpectedCommandEnv, expectedCommand)
 

--- a/pkg/terraform/upgrade_test.go
+++ b/pkg/terraform/upgrade_test.go
@@ -24,14 +24,13 @@ func TestMixin_UnmarshalUpgradeStep(t *testing.T) {
 	step := action.Steps[0]
 
 	assert.Equal(t, "Upgrade MySQL", step.Description)
-	assert.Equal(t, false, step.Input)
 }
 
 func TestMixin_Upgrade(t *testing.T) {
 	defer os.Unsetenv(test.ExpectedCommandEnv)
 	expectedCommand := strings.Join([]string{
 		"terraform init -backend=true -backend-config=key=my.tfstate -reconfigure",
-		"terraform apply -auto-approve -input=false -var myvar=foo",
+		"terraform apply -auto-approve -var myvar=foo",
 	}, "\n")
 	os.Setenv(test.ExpectedCommandEnv, expectedCommand)
 


### PR DESCRIPTION
* Removes the `input` field from a terraform step

Per https://github.com/getporter/terraform-mixin/issues/72, Porter wouldn't be able to support running a step with `input=true` as Porter's runtime is always in a non-interactive Docker container.

Closes https://github.com/getporter/terraform-mixin/issues/72