### PR TITLE
ref(*): remove deprecated autoApprove field

### DIFF
--- a/pkg/terraform/action.go
+++ b/pkg/terraform/action.go
@@ -105,9 +105,6 @@ type Instruction struct {
 
 // TerraformFields represent fields specific to Terraform
 type TerraformFields struct {
-	// AutoApprove will be deprecated in a later release, it is no longer used, --auto-approve=true is always passed to terraform
-	AutoApprove bool `yaml:"autoApprove,omitempty"`
-
 	Vars           map[string]string `yaml:"vars,omitempty"`
 	DisableVarFile bool              `yaml:"disableVarFile,omitempty"`
 	LogLevel       string            `yaml:"logLevel,omitempty"`

--- a/pkg/terraform/schema/schema.json
+++ b/pkg/terraform/schema/schema.json
@@ -34,9 +34,6 @@
             "type": "string"
           }
         },
-        "autoApprove": {
-          "type": "boolean"
-        },
         "backendConfig": {
           "type": "object"
         },
@@ -87,9 +84,6 @@
                 "type": "string"
               }
             },
-            "autoApprove": {
-              "type": "boolean"
-            },
             "backendConfig": {
               "type": "object"
             },
@@ -137,9 +131,6 @@
         "terraform": {
           "type": "object",
           "properties": {
-            "autoApprove": {
-              "type": "boolean"
-            },
             "backendConfig": {
               "type": "object"
             },


### PR DESCRIPTION
* Removes the deprecated `autoApprove` field on a terraform mixin step