### PR TITLE
Remove Terraform zip-file once it has been extracted

### DIFF
--- a/pkg/terraform/build.go
+++ b/pkg/terraform/build.go
@@ -10,7 +10,8 @@ import (
 const dockerfileLines = `ENV TERRAFORM_VERSION=%s
 RUN apt-get update && apt-get install -y wget unzip && \
  wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
- unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin
+ unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin && \
+ rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 COPY . $BUNDLE_DIR
 RUN cd %s && terraform init -backend=false
 `

--- a/pkg/terraform/build_test.go
+++ b/pkg/terraform/build_test.go
@@ -13,7 +13,8 @@ import (
 const buildOutputTemplate = `ENV TERRAFORM_VERSION=%s
 RUN apt-get update && apt-get install -y wget unzip && \
  wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
- unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin
+ unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin && \
+ rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 COPY . $BUNDLE_DIR
 RUN cd /cnab/app/terraform && terraform init -backend=false
 `


### PR DESCRIPTION
When using `terraform-mixin`, Terraform CLI will be downloaded and installed as part of the invocation image. 
The downloaded zip remained in the invocation image until now.

This PR removes the ZIP archive from the image once it has been extracted.

- [x] Tests

fixes #60 