### PR TITLE
Support writing an output to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a terraform mixin for [Porter](https://github.com/getporter/porter).
 This will install the latest mixin release via the Porter CLI.
 
 ```
-porter mixin install terraform --feed-url https://cdn.porter.sh/mixins/atom.xml
+porter mixin install terraform
 ```
 
 ## Build from source
@@ -247,7 +247,20 @@ See further examples in the [Examples](examples) directory
 As seen above, outputs can be declared for a step.  All that is needed is the name of the output.
 
 For each output listed, `terraform output <output name>` is invoked to fetch the output value
-from the state file for use by Porter.
+from the state file for use by Porter. Outputs can be saved to the filesystem so that subsequent
+steps can use the file by specifying the `destinationFile` field. This is particularly useful
+when your terraform module creates a Kubernetes cluster. In the example below, the module
+creates a cluster, and then writes the kubeconfig to /root/.kube/config so that the rest of the
+bundle can immediately use the cluster.
+
+```yaml
+install:
+  - terraform:
+      description: "Create a Kubernetes cluster"
+      outputs:
+      - name: kubeconfig
+        destinationFile: /root/.kube/config
+```
 
 See the Porter [Outputs documentation](https://porter.sh/wiring/#outputs) on how to wire up
 outputs for use in a bundle.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	get.porter.sh/porter v0.37.2
 	github.com/ghodss/yaml v1.0.0
 	github.com/gobuffalo/packr/v2 v2.8.0
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -228,9 +228,11 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmg
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/pkg/terraform/action.go
+++ b/pkg/terraform/action.go
@@ -113,6 +113,8 @@ type TerraformFields struct {
 
 type Output struct {
 	Name string `yaml:"name"`
+	// Write the output to the specified file
+	DestinationFile string `yaml:"destinationFile,omitempty"`
 }
 
 func (o Output) GetName() string {


### PR DESCRIPTION
I want to be able to generate a cluster, and save the kubeconfig to /root/.kube/config so that I can immediately use it with helm in the next step, without having to dork around with the exec mixin.

Example:

```
outputs:
  - name: kubeconfig
    destinationFile: /root/.kube/config
```

Closes #84 