### PR TITLE
Mirror plugins during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Terraform providers are installed into the bundle during porter build.
 We recommend that you put your provider declarations into a single file, e.g. "terraform/providers.tf".
 Then use `initFile` to specify the relative path to this file within workingDir.
 This will dramatically improve Docker image layer caching and performance when building, publishing and installing the bundle.
+> Note: this approach isn't suitable when using terraform modules as those need to be "initilized" as well but aren't specified in the `initFile`. You shouldn't specifiy an `initFile` in this situation.
 
 ## Terraform state
 

--- a/pkg/terraform/build.go
+++ b/pkg/terraform/build.go
@@ -10,11 +10,15 @@ import (
 
 const dockerfileLines = `
 RUN apt-get update && apt-get install -y wget unzip && \
+ apt-get clean -y && rm -rf /var/lib/apt/lists/* && \
  wget https://releases.hashicorp.com/terraform/{{.ClientVersion}}/terraform_{{.ClientVersion}}_linux_amd64.zip && \
  unzip terraform_{{.ClientVersion}}_linux_amd64.zip -d /usr/bin && \
  rm terraform_{{.ClientVersion}}_linux_amd64.zip
 COPY {{.WorkingDir}}/{{.InitFile}} $BUNDLE_DIR/{{.WorkingDir}}/
-RUN cd $BUNDLE_DIR/{{.WorkingDir}} && terraform init -backend=false
+RUN cd $BUNDLE_DIR/{{.WorkingDir}} && \
+ terraform init -backend=false && \
+ rm -fr .terraform/providers && \
+ terraform providers mirror /usr/local/share/terraform/plugins
 `
 
 // BuildInput represents stdin passed to the mixin for the build command.
@@ -24,8 +28,8 @@ type BuildInput struct {
 
 // MixinConfig represents configuration that can be set on the terraform mixin in porter.yaml
 // mixins:
-// - terraform:
-//	  version: 0.12.17
+//   - terraform:
+//     version: 0.12.17
 type MixinConfig struct {
 	ClientVersion string `yaml:"clientVersion,omitempty"`
 	InitFile      string `yaml:"initFile,omitempty"`


### PR DESCRIPTION
Fixes #90.

When we build the bundle we can and should mirror the plugins terraform would use in runtime so that the bundle will be more self sufficient and won't need to access Terraform/Hashicorp endpoints to download things.
