### PR TITLE
Added json unmarshal for potentially encoded JSON string values

### DIFF
--- a/build/testdata/bundles/terraform/porter.yaml
+++ b/build/testdata/bundles/terraform/porter.yaml
@@ -32,6 +32,11 @@ parameters:
     applyTo:
       - install
       - upgrade
+  - name: json_encoded_html_string_var
+    type: string
+    applyTo:
+      - install
+      - upgrade
   - name: complex_object_var
     type: object
     applyTo:
@@ -47,6 +52,7 @@ install:
         array_var: ${bundle.parameters.array_var}
         boolean_var: ${bundle.parameters.boolean_var}
         number_var: ${bundle.parameters.number_var}
+        json_encoded_html_string_var: ${bundle.parameters.json_encoded_html_string_var}
         complex_object_var: ${bundle.parameters.complex_object_var}
       outputs:
         - name: file_contents
@@ -54,6 +60,7 @@ install:
         - name: array_var
         - name: boolean_var
         - name: number_var
+        - name: json_encoded_html_string_var
         - name: complex_object_var
 
 upgrade:
@@ -65,6 +72,7 @@ upgrade:
         array_var: ${bundle.parameters.array_var}
         boolean_var: ${bundle.parameters.boolean_var}
         number_var: ${bundle.parameters.number_var}
+        json_encoded_html_string_var: ${bundle.parameters.json_encoded_html_string_var}
         complex_object_var: ${bundle.parameters.complex_object_var}
       outputs:
         - name: file_contents
@@ -72,6 +80,7 @@ upgrade:
         - name: array_var
         - name: boolean_var
         - name: number_var
+        - name: json_encoded_html_string_var
         - name: complex_object_var
 
 plan:
@@ -105,6 +114,11 @@ outputs:
       - upgrade
   - name: number_var
     type: number
+    applyTo:
+      - install
+      - upgrade
+  - name: json_encoded_html_string_var
+    type: string
     applyTo:
       - install
       - upgrade

--- a/build/testdata/bundles/terraform/porter.yaml
+++ b/build/testdata/bundles/terraform/porter.yaml
@@ -32,6 +32,11 @@ parameters:
     applyTo:
       - install
       - upgrade
+  - name: complex_object_var
+    type: object
+    applyTo:
+      - install
+      - upgrade
 
 install:
   - terraform:
@@ -42,13 +47,14 @@ install:
         array_var: ${bundle.parameters.array_var}
         boolean_var: ${bundle.parameters.boolean_var}
         number_var: ${bundle.parameters.number_var}
+        complex_object_var: ${bundle.parameters.complex_object_var}
       outputs:
         - name: file_contents
         - name: map_var
         - name: array_var
         - name: boolean_var
         - name: number_var
-        - name: json_encode_html
+        - name: complex_object_var
 
 upgrade:
   - terraform:
@@ -59,13 +65,14 @@ upgrade:
         array_var: ${bundle.parameters.array_var}
         boolean_var: ${bundle.parameters.boolean_var}
         number_var: ${bundle.parameters.number_var}
+        complex_object_var: ${bundle.parameters.complex_object_var}
       outputs:
         - name: file_contents
         - name: map_var
         - name: array_var
         - name: boolean_var
         - name: number_var
-        - name: json_encode_html
+        - name: complex_object_var
 
 plan:
   - terraform:
@@ -101,8 +108,8 @@ outputs:
     applyTo:
       - install
       - upgrade
-  - name: json_encode_html
-    type: string
+  - name: complex_object_var
+    type: object
     applyTo:
       - install
       - upgrade

--- a/build/testdata/bundles/terraform/porter.yaml
+++ b/build/testdata/bundles/terraform/porter.yaml
@@ -48,6 +48,7 @@ install:
         - name: array_var
         - name: boolean_var
         - name: number_var
+        - name: json_encode_html
 
 upgrade:
   - terraform:
@@ -64,6 +65,7 @@ upgrade:
         - name: array_var
         - name: boolean_var
         - name: number_var
+        - name: json_encode_html
 
 plan:
   - terraform:
@@ -96,6 +98,11 @@ outputs:
       - upgrade
   - name: number_var
     type: number
+    applyTo:
+      - install
+      - upgrade
+  - name: json_encode_html
+    type: string
     applyTo:
       - install
       - upgrade

--- a/build/testdata/bundles/terraform/terraform/outputs.tf
+++ b/build/testdata/bundles/terraform/terraform/outputs.tf
@@ -18,3 +18,7 @@ output "boolean_var" {
 output "number_var" {
   value = var.number_var
 }
+
+output "json_encode_html" {
+  value = "hello&world"
+}

--- a/build/testdata/bundles/terraform/terraform/outputs.tf
+++ b/build/testdata/bundles/terraform/terraform/outputs.tf
@@ -19,6 +19,10 @@ output "number_var" {
   value = var.number_var
 }
 
+output "json_encoded_html_string_var" {
+   value = var.json_encoded_html_string_var
+ }
+
 output "complex_object_var" {
   value = var.complex_object_var
 }

--- a/build/testdata/bundles/terraform/terraform/outputs.tf
+++ b/build/testdata/bundles/terraform/terraform/outputs.tf
@@ -20,5 +20,5 @@ output "number_var" {
 }
 
 output "json_encode_html" {
-  value = "hello&world"
+  value = "hello&world?@test#$><"
 }

--- a/build/testdata/bundles/terraform/terraform/outputs.tf
+++ b/build/testdata/bundles/terraform/terraform/outputs.tf
@@ -19,6 +19,6 @@ output "number_var" {
   value = var.number_var
 }
 
-output "json_encode_html" {
-  value = "hello&world?@test#$><"
+output "complex_object_var" {
+  value = var.complex_object_var
 }

--- a/build/testdata/bundles/terraform/terraform/variables.tf
+++ b/build/testdata/bundles/terraform/terraform/variables.tf
@@ -3,7 +3,7 @@ variable "file_contents" {
   default     = "bar"
 }
 variable "map_var" {
-  description = "Object variable"
+  description = "Map variable"
   type        = map(string)
   default     = { foo = "bar" }
 }
@@ -24,4 +24,13 @@ variable "number_var" {
   description = "Number Variable"
   type        = number
   default     = 0
+}
+variable "complex_object_var" {
+  description = "Object variable"
+  type        = object({
+    top_value = string
+    nested_object = object({
+      internal_value = string
+    })
+  })
 }

--- a/build/testdata/bundles/terraform/terraform/variables.tf
+++ b/build/testdata/bundles/terraform/terraform/variables.tf
@@ -40,4 +40,10 @@ variable "complex_object_var" {
       internal_value = string
     })
   })
+  default = {
+    top_value = "top_value"
+    nested_object = {
+      internal_value = "internal"
+    }
+  }
 }

--- a/build/testdata/bundles/terraform/terraform/variables.tf
+++ b/build/testdata/bundles/terraform/terraform/variables.tf
@@ -25,6 +25,13 @@ variable "number_var" {
   type        = number
   default     = 0
 }
+
+variable "json_encoded_html_string_var" {
+  description = "String variable with html characters that should not be escaped"
+  type = string
+  default = "hello&world"
+}
+
 variable "complex_object_var" {
   description = "Object variable"
   type        = object({

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -54,6 +54,10 @@ func (m *Mixin) getPayloadData() ([]byte, error) {
 }
 
 func (m *Mixin) getOutput(outputName string) ([]byte, error) {
+	// Using -json instead of -raw because terraform only allows for string, bool,
+	// and number output types when using -raw. This means that the outputs will
+	// need to be unencoded to raw string because -json does json compliant html
+	// special character encoding.
 	cmd := m.NewCommand("terraform", "output", "-json", outputName)
 	cmd.Stderr = m.Err
 

--- a/scripts/test/test-cli.sh
+++ b/scripts/test/test-cli.sh
@@ -41,7 +41,7 @@ verify-output "map_var" '{"foo":"bar"}'
 verify-output "array_var" '["hello","world"]'
 verify-output "boolean_var" 'true'
 verify-output "number_var" '1'
-verify-output "json_encode_html" "hello&world"
+verify-output "json_encode_html" "hello&world?@test#$><"
 
 ${PORTER_HOME}/porter invoke --verbosity=debug --action=plan --debug
 
@@ -53,6 +53,6 @@ verify-output "map_var" '{"bar":"baz"}'
 verify-output "array_var" '["goodbye","world"]'
 verify-output "boolean_var" 'false'
 verify-output "number_var" '2'
-verify-output "json_encode_html" "hello&world"
+verify-output "json_encode_html" "hello&world?@test#$><"
 
 ${PORTER_HOME}/porter uninstall --debug

--- a/scripts/test/test-cli.sh
+++ b/scripts/test/test-cli.sh
@@ -33,26 +33,39 @@ cp -r ${REPO_DIR}/build/testdata/bundles/terraform/terraform .
 cp ${REPO_DIR}/build/testdata/bundles/terraform/porter.yaml .
 
 ${PORTER_HOME}/porter build
-${PORTER_HOME}/porter install --verbosity=debug --param file_contents='foo!' --param map_var='{"foo": "bar"}' --param array_var='["hello", "world"]' --param boolean_var=true --param number_var=1 --force
+${PORTER_HOME}/porter install --verbosity=debug \
+  --param file_contents='foo!' \
+  --param map_var='{"foo": "bar"}' \
+  --param array_var='["mylist", "https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/rg-scctre-ws-935d/providers/Microsoft.MachineLearningServices/workspaces/ml-scctre-ws-935d-svc-0cdf&tid=zzzzz"]' \
+  --param boolean_var=true \
+  --param number_var=1 \
+  --param complex_object_var='{"top_value": "https://my.service?test=$id<>", "nested_object": {"internal_value": "https://my.connection.com?test&test=$hello"}}' \
+  --force
 
 echo "Verifying installation output after install"
 verify-output "file_contents" 'foo!'
 verify-output "map_var" '{"foo":"bar"}'
-verify-output "array_var" '["hello","world"]'
+verify-output "array_var" '["mylist","https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/rg-scctre-ws-935d/providers/Microsoft.MachineLearningServices/workspaces/ml-scctre-ws-935d-svc-0cdf&tid=zzzzz"]'
 verify-output "boolean_var" 'true'
 verify-output "number_var" '1'
-verify-output "json_encode_html" "hello&world?@test#$><"
+verify-output "complex_object_var" '{"nested_object":{"internal_value":"https://my.connection.com?test&test=$hello"},"top_value":"https://my.service?test=$id<>"}'
 
 ${PORTER_HOME}/porter invoke --verbosity=debug --action=plan --debug
 
-${PORTER_HOME}/porter upgrade --verbosity=debug --param file_contents='bar!' --param map_var='{"bar": "baz"}' --param array_var='["goodbye", "world"]' --param boolean_var=false --param number_var=2
+${PORTER_HOME}/porter upgrade --verbosity=debug \
+  --param file_contents='bar!' \
+  --param map_var='{"bar": "baz"}' \
+  --param array_var='["mylist", "https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/rg-scctre-ws-935d/providers/Microsoft.MachineLearningServices/workspaces/ml-scctre-ws-935d-svc-0cdf&tid=zzzzz"]' \
+  --param boolean_var=false \
+  --param number_var=2 \
+  --param complex_object_var='{"top_value": "https://my.updated.service?test=$id<>", "nested_object": {"internal_value": "https://new.connection.com?test&test=$hello"}}'
 
 echo "Verifying installation output after upgrade"
 verify-output "file_contents" 'bar!'
 verify-output "map_var" '{"bar":"baz"}'
-verify-output "array_var" '["goodbye","world"]'
+verify-output "array_var" '["mylist","https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/rg-scctre-ws-935d/providers/Microsoft.MachineLearningServices/workspaces/ml-scctre-ws-935d-svc-0cdf&tid=zzzzz"]'
 verify-output "boolean_var" 'false'
 verify-output "number_var" '2'
-verify-output "json_encode_html" "hello&world?@test#$><"
+verify-output "complex_object_var" '{"nested_object":{"internal_value":"https://new.connection.com?test&test=$hello"},"top_value":"https://my.updated.service?test=$id<>"}'
 
 ${PORTER_HOME}/porter uninstall --debug

--- a/scripts/test/test-cli.sh
+++ b/scripts/test/test-cli.sh
@@ -36,36 +36,40 @@ ${PORTER_HOME}/porter build
 ${PORTER_HOME}/porter install --verbosity=debug \
   --param file_contents='foo!' \
   --param map_var='{"foo": "bar"}' \
-  --param array_var='["mylist", "https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/rg-scctre-ws-935d/providers/Microsoft.MachineLearningServices/workspaces/ml-scctre-ws-935d-svc-0cdf&tid=zzzzz"]' \
+  --param array_var='["mylist", "https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/some-rsg/providers/Microsoft.MachineLearningServices/workspaces/myworkspace&tid=zzzzz"]' \
   --param boolean_var=true \
   --param number_var=1 \
+  --param json_encoded_html_string_var='testing?connection&string=<>' \
   --param complex_object_var='{"top_value": "https://my.service?test=$id<>", "nested_object": {"internal_value": "https://my.connection.com?test&test=$hello"}}' \
   --force
 
 echo "Verifying installation output after install"
 verify-output "file_contents" 'foo!'
 verify-output "map_var" '{"foo":"bar"}'
-verify-output "array_var" '["mylist","https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/rg-scctre-ws-935d/providers/Microsoft.MachineLearningServices/workspaces/ml-scctre-ws-935d-svc-0cdf&tid=zzzzz"]'
+verify-output "array_var" '["mylist","https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/some-rsg/providers/Microsoft.MachineLearningServices/workspaces/myworkspace&tid=zzzzz"]'
 verify-output "boolean_var" 'true'
 verify-output "number_var" '1'
 verify-output "complex_object_var" '{"nested_object":{"internal_value":"https://my.connection.com?test&test=$hello"},"top_value":"https://my.service?test=$id<>"}'
+verify-output "json_encoded_html_string_var" 'testing?connection&string=<>'
 
 ${PORTER_HOME}/porter invoke --verbosity=debug --action=plan --debug
 
 ${PORTER_HOME}/porter upgrade --verbosity=debug \
   --param file_contents='bar!' \
   --param map_var='{"bar": "baz"}' \
-  --param array_var='["mylist", "https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/rg-scctre-ws-935d/providers/Microsoft.MachineLearningServices/workspaces/ml-scctre-ws-935d-svc-0cdf&tid=zzzzz"]' \
+  --param array_var='["mylist", "https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/some-rsg/providers/Microsoft.MachineLearningServices/workspaces/myworkspace&tid=zzzzz"]' \
   --param boolean_var=false \
   --param number_var=2 \
+  --param json_encoded_html_string_var='?new#conn&string$characters~!' \
   --param complex_object_var='{"top_value": "https://my.updated.service?test=$id<>", "nested_object": {"internal_value": "https://new.connection.com?test&test=$hello"}}'
 
 echo "Verifying installation output after upgrade"
 verify-output "file_contents" 'bar!'
 verify-output "map_var" '{"bar":"baz"}'
-verify-output "array_var" '["mylist","https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/rg-scctre-ws-935d/providers/Microsoft.MachineLearningServices/workspaces/ml-scctre-ws-935d-svc-0cdf&tid=zzzzz"]'
+verify-output "array_var" '["mylist","https://ml.azure.com/?wsid=/subscriptions/zzzz/resourceGroups/some-rsg/providers/Microsoft.MachineLearningServices/workspaces/myworkspace&tid=zzzzz"]'
 verify-output "boolean_var" 'false'
 verify-output "number_var" '2'
+verify-output "json_encoded_html_string_var" '?new#conn&string$characters~!'
 verify-output "complex_object_var" '{"nested_object":{"internal_value":"https://new.connection.com?test&test=$hello"},"top_value":"https://my.updated.service?test=$id<>"}'
 
 ${PORTER_HOME}/porter uninstall --debug

--- a/scripts/test/test-cli.sh
+++ b/scripts/test/test-cli.sh
@@ -33,7 +33,7 @@ cp -r ${REPO_DIR}/build/testdata/bundles/terraform/terraform .
 cp ${REPO_DIR}/build/testdata/bundles/terraform/porter.yaml .
 
 ${PORTER_HOME}/porter build
-${PORTER_HOME}/porter install --verbosity=debug --param file_contents='foo!' --param map_var='{"foo": "bar"}' --param array_var='["hello", "world"]' --param boolean_var=true --param number_var=1
+${PORTER_HOME}/porter install --verbosity=debug --param file_contents='foo!' --param map_var='{"foo": "bar"}' --param array_var='["hello", "world"]' --param boolean_var=true --param number_var=1 --force
 
 echo "Verifying installation output after install"
 verify-output "file_contents" 'foo!'
@@ -41,6 +41,7 @@ verify-output "map_var" '{"foo":"bar"}'
 verify-output "array_var" '["hello","world"]'
 verify-output "boolean_var" 'true'
 verify-output "number_var" '1'
+verify-output "json_encode_html" "hello&world"
 
 ${PORTER_HOME}/porter invoke --verbosity=debug --action=plan --debug
 
@@ -52,5 +53,6 @@ verify-output "map_var" '{"bar":"baz"}'
 verify-output "array_var" '["goodbye","world"]'
 verify-output "boolean_var" 'false'
 verify-output "number_var" '2'
+verify-output "json_encode_html" "hello&world"
 
 ${PORTER_HOME}/porter uninstall --debug


### PR DESCRIPTION
Signed-off-by: Steven Gettys <s.gettys@f5.com>

Closes #94 
Terraform outputs from porter included escaped html characters for things like connection strings. This is a regression due to switching from -raw to -json. The reason the switch occurred is because -raw only supports number, boolean, and string outputs from terraform.

The mixin will decode all of the json strings and remove the html escapes. This works for complex nested objects like arrays and maps as well as strings