### PR TITLE
Include mixin declaration schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ replace (
 require (
 	get.porter.sh/magefiles v0.3.2
 	get.porter.sh/porter v1.0.0-rc.2
+	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/carolynvs/magex v0.9.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -36,7 +37,6 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/PaesslerAG/gval v1.0.0 // indirect
-	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
 	github.com/PuerkitoBio/goquery v1.5.0 // indirect
 	github.com/andybalholm/brotli v1.0.1 // indirect
 	github.com/andybalholm/cascadia v1.0.0 // indirect

--- a/pkg/terraform/schema/schema.json
+++ b/pkg/terraform/schema/schema.json
@@ -1,6 +1,43 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "declaration": {
+      "oneOf": [
+        {
+          "description": "Declare the terraform mixin without configuration",
+          "type": "string",
+          "enum": ["terraform"]
+        },
+        {"$ref": "#/definitions/config"}
+      ]
+    },
+    "config": {
+      "description": "Declare the terraform mixin with additional configuration",
+      "type": "object",
+      "properties": {
+        "terraform": {
+          "description": "terraform mixin configuration",
+          "type": "object",
+          "properties": {
+            "clientVersion": {
+              "description": "Version of terraform to install in the bundle",
+              "type": "string"
+            },
+            "initFile": {
+              "description": "Relative path from the workingDir to a file defining all providers, used when running terraform init.",
+              "type": "string"
+            },
+            "workingDir": {
+              "description": "Relative path to your terraform files, defaults to 'terraform'",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["terraform"]
+    },
     "installStep": {
       "type": "object",
       "properties": {
@@ -191,15 +228,16 @@
       "items": {
         "$ref": "#/definitions/uninstallStep"
       }
-    }
-  },
-  "patternProperties": {
-    ".*": {
+    },
+     "mixins": {
       "type": "array",
-      "items": {
-        "$ref": "#/definitions/invokeStep"
-      }
+      "items": { "$ref": "#/definitions/declaration" }
     }
   },
-  "additionalProperties": false
+  "additionalProperties": {
+    "type": "array",
+    "items": {
+      "$ref": "#/definitions/invokeStep"
+    }
+  }
 }


### PR DESCRIPTION
Include the mixin declaration in the results of the schema command. This way VS Code displays proper highlighting and autocompletion when setting configuration settings when declaring the mixin, such as a client version.