### PR TITLE
Convert porter/terraform-mixin to GitHub Actions

### DIFF
--- a/.github/workflows/terraform-mixin.yml
+++ b/.github/workflows/terraform-mixin.yml
@@ -1,0 +1,31 @@
+name: porter/terraform-mixin
+on:
+  push:
+    branches:
+    - main
+    - v*
+  pull_request:
+    branches:
+    - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+#     # This item has no matching transformer
+#     - task: GoTool@0
+#       inputs:
+#         version: 1.19.2
+#       displayName: Install Go
+    - name: Configure Agent
+      run: go run mage.go ConfigureAgent
+    - name: Test
+      run: mage Test
+    - name: Cross Compile
+      run: mage XBuildAll
+    - name: Publish
+      if: success() && github.event_name != 'PullRequest'
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: mage Publish


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/getporter/porter/_build?definitionId=10) :tada:

## Manual steps

Perform the following steps to complete the migration:

### porter/terraform-mixin
- [ ] Ensure secret is available: `${{ secrets.GITHUB_TOKEN }}`