### PR TITLE
Add tag triggers for mixin workflow

### DIFF
--- a/.github/workflows/terraform-mixin.yml
+++ b/.github/workflows/terraform-mixin.yml
@@ -4,6 +4,10 @@ on:
     branches:
     - main
     - v*
+    tags:
+    - v*
+    - "!canary*"
+    - "!latest*"
   pull_request:
     branches:
     - main


### PR DESCRIPTION
- Add version tags (v*) as workflow triggers
- Exclude canary and latest tags from triggering workflow

Otherwise a new version won't be release when creaing the release tag. It is a mistake during from the conversion from Azure Pipelines to Github Actions that it wasn't triggering on tags