### PR TITLE
feat(build): support installing terraform or providers in airgapped env

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ porter mixin install terraform
 ## Build from source
 
 Following commands build the terraform mixin.
+
 ```bash
 git clone https://github.com/getporter/terraform-mixin.git
 cd terraform-mixin
@@ -36,20 +37,37 @@ mixins:
     clientVersion: 1.0.3
     workingDir: myinfra
     initFile: providers.tf
+    installHost: install.example.com
+    providerHost: providers.example.com
 ```
 
 ### clientVersion
+
 The Terraform client version can be specified via the `clientVersion` configuration when declaring this mixin.
 
 ### workingDir
+
 The `workingDir` configuration setting is the relative path to your terraform files. Defaults to "terraform".
 
 ### initFile
-Terraform providers are installed into the bundle during porter build. 
+
+Terraform providers are installed into the bundle during porter build.
 We recommend that you put your provider declarations into a single file, e.g. "terraform/providers.tf".
 Then use `initFile` to specify the relative path to this file within workingDir.
 This will dramatically improve Docker image layer caching and performance when building, publishing and installing the bundle.
 > Note: this approach isn't suitable when using terraform modules as those need to be "initilized" as well but aren't specified in the `initFile`. You shouldn't specifiy an `initFile` in this situation.
+
+### installHost
+
+Optional host that mirrors the official terraform installation at
+`https://releases.hashicorp.com/*` in order to install in an air-gapped
+environment.
+
+### providerHost
+
+Optional host to use as a network mirror when installing terraform providers.
+This needs to conform to the [Terraform registry
+protocol](https://www.terraform.io/docs/internals/provider-registry-protocol.html).
 
 ### User Agent Opt Out
 
@@ -116,10 +134,9 @@ The specified path inside the installer (`/cnab/app/terraform/terraform.tfstate`
 
 Alternatively, state can be managed by a remote backend.  When doing so, each action step needs to supply the remote backend config via `backendConfig`.  In the step examples below, the configuration has key/value pairs according to the [Azurerm](https://www.terraform.io/docs/backends/types/azurerm.html) backend.
 
-
 ## Terraform variables file
 
-By default the mixin will create a default 
+By default the mixin will create a default
 [`terraform.tfvars.json`](https://www.terraform.io/docs/language/values/variables.html#variable-definitions-tfvars-files)
 file from the `vars` block during during the install step.
 

--- a/pkg/terraform/build_test.go
+++ b/pkg/terraform/build_test.go
@@ -18,8 +18,22 @@ func TestMixin_Build(t *testing.T) {
 		expectedVersion   string
 		expectedUserAgent string
 	}{
-		{name: "build with custom config", inputFile: "testdata/build-input-with-config.yaml", expectedVersion: "https://releases.hashicorp.com/terraform/0.13.0-rc1/terraform_0.13.0-rc1_linux_amd64.zip", expectedUserAgent: "ENV PORTER_TERRAFORM_MIXIN_USER_AGENT_OPT_OUT=\"true\"\nENV AZURE_HTTP_USER_AGENT=\"\""},
-		{name: "build with the default Terraform config", expectedVersion: "https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_amd64.zip", expectedUserAgent: "ENV PORTER_TERRAFORM_MIXIN_USER_AGENT_OPT_OUT=\"false\"\nENV AZURE_HTTP_USER_AGENT=\"getporter/porter getporter/terraform/v1.2.3"},
+		{
+			name:              "build with custom config",
+			inputFile:         "testdata/build-input-with-config.yaml",
+			expectedVersion:   "https://releases.hashicorp.com/terraform/0.13.0-rc1/terraform_0.13.0-rc1_linux_amd64.zip",
+			expectedUserAgent: "ENV PORTER_TERRAFORM_MIXIN_USER_AGENT_OPT_OUT=\"true\"\nENV AZURE_HTTP_USER_AGENT=\"\"",
+		},
+		{
+			name:              "build with the default Terraform config",
+			expectedVersion:   "https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_amd64.zip",
+			expectedUserAgent: "ENV PORTER_TERRAFORM_MIXIN_USER_AGENT_OPT_OUT=\"false\"\nENV AZURE_HTTP_USER_AGENT=\"getporter/porter getporter/terraform/v1.2.3",
+		},
+		{
+			name:            "build in airgrapped environment",
+			inputFile:       "testdata/build-input-in-airgapped-env.yaml",
+			expectedVersion: "https://install.example.com/terraform/1.2.3/terraform_1.2.3_linux_amd64.zip",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/terraform/build_test.go
+++ b/pkg/terraform/build_test.go
@@ -13,10 +13,11 @@ import (
 
 func TestMixin_Build(t *testing.T) {
 	testcases := []struct {
-		name              string
-		inputFile         string
-		expectedVersion   string
-		expectedUserAgent string
+		name                 string
+		inputFile            string
+		expectedVersion      string
+		expectedUserAgent    string
+		expectedProviderHost string
 	}{
 		{
 			name:              "build with custom config",
@@ -30,9 +31,10 @@ func TestMixin_Build(t *testing.T) {
 			expectedUserAgent: "ENV PORTER_TERRAFORM_MIXIN_USER_AGENT_OPT_OUT=\"false\"\nENV AZURE_HTTP_USER_AGENT=\"getporter/porter getporter/terraform/v1.2.3",
 		},
 		{
-			name:            "build in airgrapped environment",
-			inputFile:       "testdata/build-input-in-airgapped-env.yaml",
-			expectedVersion: "https://install.example.com/terraform/1.2.3/terraform_1.2.3_linux_amd64.zip",
+			name:                 "build in airgrapped environment",
+			inputFile:            "testdata/build-input-in-airgapped-env.yaml",
+			expectedVersion:      "https://install.example.com/terraform/1.2.3/terraform_1.2.3_linux_amd64.zip",
+			expectedProviderHost: "https://providers.example.com",
 		},
 	}
 
@@ -57,6 +59,13 @@ func TestMixin_Build(t *testing.T) {
 			gotOutput := m.TestContext.GetOutput()
 			assert.Contains(t, gotOutput, tc.expectedVersion)
 			assert.Contains(t, gotOutput, tc.expectedUserAgent)
+
+			if tc.expectedProviderHost != "" {
+				assert.Contains(t, gotOutput, tc.expectedProviderHost)
+			} else {
+				assert.NotContains(t, gotOutput, "network_mirror")
+			}
+
 			assert.NotContains(t, "{{.", gotOutput, "Not all of the template values were consumed")
 		})
 	}

--- a/pkg/terraform/testdata/build-input-in-airgapped-env.yaml
+++ b/pkg/terraform/testdata/build-input-in-airgapped-env.yaml
@@ -1,0 +1,4 @@
+config:
+  clientVersion: 1.2.3
+  installHost: https://install.example.com
+  providerHost: https://providers.example.com/


### PR DESCRIPTION
This makes it possible to mirror the hashicorp official install host and installing terraform in an environment where the official release host is not reachable.

Moreover, this also adds the ability to provide a provider mirror host from which to install providers when the official regsitry is not reachable.

Fixes #123.