### PR TITLE
fix(build): add env var to point to provider config

### DIFF
--- a/pkg/terraform/build.go
+++ b/pkg/terraform/build.go
@@ -18,9 +18,10 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
  unzip terraform_{{.ClientVersion}}_linux_amd64.zip -d /usr/bin && \
  rm terraform_{{.ClientVersion}}_linux_amd64.zip
 COPY {{.WorkingDir}}/{{.InitFile}} $BUNDLE_DIR/{{.WorkingDir}}/
-RUN cd $BUNDLE_DIR/{{.WorkingDir}} && \
+RUN cd $BUNDLE_DIR/{{.WorkingDir}} && mkdir -p /usr/local/share/terraform/plugins/
 {{if .ProviderHost }}
- tee <<EOF > provider_mirror.tfrc && terraform init -backend=false && mkdir -p /usr/local/share/terraform/plugins/ && cp --recursive .terraform/providers /usr/local/share/terraform/plugins/
+ENV TF_CLI_CONFIG_FILE=$BUNDLE_DIR/{{.WorkingDir}}/provider_mirror.tfrc
+RUN tee <<EOF > provider_mirror.tfrc && terraform init -backend=false && cp --recursive .terraform/providers /usr/local/share/terraform/plugins/
   provider_installation {
       direct {
           exclude = ["registry.terraform.io/*/*"]
@@ -31,7 +32,7 @@ RUN cd $BUNDLE_DIR/{{.WorkingDir}} && \
   }
 EOF
 {{ else }}
-  terraform init -backend=false && \
+RUN terraform init -backend=false && \
   rm -fr .terraform/providers && \
   terraform providers mirror /usr/local/share/terraform/plugins
 {{ end }}

--- a/pkg/terraform/build_test.go
+++ b/pkg/terraform/build_test.go
@@ -62,8 +62,10 @@ func TestMixin_Build(t *testing.T) {
 
 			if tc.expectedProviderHost != "" {
 				assert.Contains(t, gotOutput, tc.expectedProviderHost)
+				assert.Contains(t, gotOutput, "ENV TF_CLI_CONFIG_FILE=")
 			} else {
 				assert.NotContains(t, gotOutput, "network_mirror")
+				assert.NotContains(t, gotOutput, "TF_CLI_CONFIG_FILE")
 			}
 
 			assert.NotContains(t, "{{.", gotOutput, "Not all of the template values were consumed")


### PR DESCRIPTION
Without this in the generated dockerfile snippet, the user will have to add this environment variable to their own dockerfile and know the path to where the provider configuration file is written.

Workaround currently is to add this to the dockerfile of the bundle before `# PORTER_MIXINS`:

```Dockerfile
ENV TF_CLI_CONFIG_FILE=${BUNDLE_DIR}/${terraform_workdir}/provider_mirror.tfrc
```

where `${terraform_workdir}` is the working dir as configured in the mixin declaration.

Follow up PR to #125.